### PR TITLE
Release assets only return latest rollback

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -24,6 +24,16 @@ add_filter(
 		);
 	}
 );
+add_filter(
+	'github_updater_release_asset_rollback',
+	function ( $rollback, $file ) {
+		if ( $file === plugin_basename( __FILE__ ) ) {
+			return [ 'gutenberg-nightly' ];
+		}
+	},
+	10,
+	2
+);
 add_filter( 'github_updater_no_release_asset_branches', '__return_true' );
 // End GitHub Updater filters.
 

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -24,12 +24,6 @@ add_filter(
 		);
 	}
 );
-add_filter(
-	'github_updater_number_rollbacks',
-	function () {
-		return 2;
-	}
-);
 add_filter( 'github_updater_no_release_asset_branches', '__return_true' );
 // End GitHub Updater filters.
 


### PR DESCRIPTION
Release assets are only capable of a re-install, they cannot revert to an older release asset.
