### PR TITLE
Update for new Git Updater hooks

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -18,7 +18,7 @@
 
 // GitHub Updater filters.
 add_filter(
-	'github_updater_override_dot_org',
+	'gu_override_dot_org',
 	function ( $overrides ) {
 		return array_merge(
 			$overrides,
@@ -27,7 +27,7 @@ add_filter(
 	}
 );
 add_filter(
-	'github_updater_release_asset_rollback',
+	'gu_release_asset_rollback',
 	function ( $rollback, $file ) {
 		if ( $file === plugin_basename( __FILE__ ) ) {
 			return [ 'gutenberg-nightly' ];
@@ -36,7 +36,7 @@ add_filter(
 	10,
 	2
 );
-add_filter( 'github_updater_no_release_asset_branches', '__return_true' );
+add_filter( 'gu_no_release_asset_branches', '__return_true' );
 // End GitHub Updater filters.
 
 


### PR DESCRIPTION

## Description
The previous hooks will send a deprecated notice that WP writes with a `die()`.

These are the new hooks for Git Updater v10+

## How has this been tested?
Tested in new Git Updater v10+

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
