### PR TITLE
Git Updater Lite  integration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,8 +41,8 @@
 		}
 	],
 	"require": {
-		"php": ">=7.4",
-		"composer/installers": "^1.0 || ^2.0"
+		"composer/installers": "^1.0 || ^2.0",
+		"afragen/git-updater-lite": "^3"
 	},
 	"scripts": {
 		"format": "phpcbf --standard=phpcs.xml.dist --report-summary --report-source",

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -9,35 +9,18 @@
  * Version: 23.7.20260716
  * Author: Gutenberg Team and Birgit Pauli-Haack (Gutenberg Times)
  * Text Domain: gutenberg
- * GitHub Plugin URI: bph/gutenberg
- * Primary Branch: trunk
- * Release Asset: true
+ * Update URI: https://gutenbergtimes.com
  *
  * @package gutenberg
  */
 
-// GitHub Updater filters.
-add_filter(
-	'gu_override_dot_org',
-	function ( $overrides ) {
-		return array_merge(
-			$overrides,
-			array( 'gutenberg/gutenberg.php' )
-		);
-	}
-);
-add_filter(
-	'gu_release_asset_rollback',
-	function ( $rollback, $file ) {
-		if ( $file === plugin_basename( __FILE__ ) ) {
-			return [ 'gutenberg-nightly' ];
-		}
-	},
-	10,
-	2
-);
-add_filter( 'gu_no_release_asset_branches', '__return_true' );
-// End GitHub Updater filters.
+ // Initialize Git Updater Lite.
+ require_once __DIR__ . '/vendor/afragen/git-updater-lite/Lite.php';
+( new \Fragen\Git_Updater\Lite( __FILE__ ) )->run();
+
+// Get dev release assets for Gutenberg plugin.
+add_filter( 'gu_dev_release_asset', fn( $bool, $repo ) => ( 'gutenberg' === $repo->slug ), 10, 2 );
+
 
 
 ### BEGIN AUTO-GENERATED DEFINES

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -10,17 +10,45 @@
  * Author: Gutenberg Team and Birgit Pauli-Haack (Gutenberg Times)
  * Text Domain: gutenberg
  * Update URI: https://gutenbergtimes.com
+ * GitHub Plugin URI: bph/gutenberg
+ * Primary Branch: trunk
+ * Release Asset: true
  *
  * @package gutenberg
  */
 
+// Add the development channel to the Git Updater Lite API URL for the Gutenberg plugin.
+add_filter( 'git_updater_lite_api_url', fn( $url, $slug ) => ( 'gutenberg' === $slug ) ? add_query_arg( [ 'channel' => 'development' ], $url ) : $url, 10, 2 );
+
  // Initialize Git Updater Lite.
- require_once __DIR__ . '/vendor/afragen/git-updater-lite/Lite.php';
-( new \Fragen\Git_Updater\Lite( __FILE__ ) )->run();
+ if ( file_exists( __DIR__ . '/vendor/afragen/git-updater-lite/Lite.php' ) ) {
+	require_once __DIR__ . '/vendor/afragen/git-updater-lite/Lite.php';
+	( new \Fragen\Git_Updater\Lite( __FILE__ ) )->run();
+}
 
-// Get dev release assets for Gutenberg plugin.
-add_filter( 'gu_dev_release_asset', fn( $bool, $repo ) => ( 'gutenberg' === $repo->slug ), 10, 2 );
 
+// GitHub Updater filters.
+add_filter(
+	'gu_override_dot_org',
+	function ( $overrides ) {
+		return array_merge(
+			$overrides,
+			array( 'gutenberg/gutenberg.php' )
+		);
+	}
+);
+add_filter(
+	'gu_release_asset_rollback',
+	function ( $rollback, $file ) {
+		if ( $file === plugin_basename( __FILE__ ) ) {
+			return [ 'gutenberg-nightly' ];
+		}
+	},
+	10,
+	2
+);
+add_filter( 'gu_no_release_asset_branches', '__return_true' );
+// End GitHub Updater filters.
 
 
 ### BEGIN AUTO-GENERATED DEFINES


### PR DESCRIPTION
This PR provides an integration with GUL for a self-contained updater.

This PR does NOT include running `composer update` as it seems this project would do this in a GitHub Action during the release process.

It also requires that https://gutenbergtimes.com has Git Updater installed, active, and that Gutenberg Nightly is added via the Additions tab.

<img width="1224" height="195" alt="screenshot_871" src="https://github.com/user-attachments/assets/fe5eaae5-bb18-4d31-9752-281d87eebace" />
